### PR TITLE
Add Maddie Lam member photo

### DIFF
--- a/cache/team.json
+++ b/cache/team.json
@@ -674,7 +674,7 @@
       "name": "Maddie Lam",
       "role": "Writer",
       "bio": "I get a little sillay\n",
-      "imageUrl": "",
+      "imageUrl": "/member-photos/Maddie%20Lam.jpg",
       "imageType": "url",
       "imagePath": null,
       "photoSub": [

--- a/client/src/pages/team-detail.tsx
+++ b/client/src/pages/team-detail.tsx
@@ -9,6 +9,7 @@ import { Link } from "wouter";
 import { formatDate } from "@/lib/utils";
 import { getImageUrl, getPhotoUrl } from "@/lib/image-helper";
 import { fetchTeamMemberById, fetchArticlesByIds } from "@/lib/api";
+import { Article } from "@shared/schema";
 
 export default function TeamMemberDetail() {
   const { id } = useParams();


### PR DESCRIPTION
## Summary
- Add Maddie Lam member photo to public assets
- Point Maddie Lam's team cache entry at the uploaded photo
- Add the missing Article type import in the team detail page

## Test
- npm run check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restored missing team member profile photo that was not displaying.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pinkytoedev/PinkyToeWebsite/pull/11?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->