### PR TITLE
Space the marquee's loop seam like the gaps inside it

### DIFF
--- a/client/src/components/ui/marquee.tsx
+++ b/client/src/components/ui/marquee.tsx
@@ -20,6 +20,7 @@ export function Marquee({
   children,
 }: MarqueeProps) {
   const containerRef = React.useRef<HTMLDivElement>(null);
+  const trackRef = React.useRef<HTMLDivElement>(null);
   const contentRef = React.useRef<HTMLDivElement>(null);
   const [isPaused, setIsPaused] = React.useState(false);
   const [childrenArray, setChildrenArray] = React.useState<React.ReactNode[]>([]);
@@ -35,12 +36,23 @@ export function Marquee({
   const calculateDuration = React.useCallback(() => {
     if (!contentRef.current) return;
 
-    const measuredWidth = contentRef.current.scrollWidth;
+    // Fractional width, not scrollWidth: the integer rounding shows up as a
+    // visible jump every time the loop restarts.
+    const measuredWidth =
+      contentRef.current.getBoundingClientRect().width || contentRef.current.scrollWidth;
     if (measuredWidth === 0) return;
 
+    // The copy has to travel its own width *plus* the gap separating it from
+    // the duplicate, or the seam closes up and two quotes collide once per lap.
+    // Read the gap rather than hard-coding it so it tracks the class below.
+    const gap = trackRef.current
+      ? parseFloat(window.getComputedStyle(trackRef.current).columnGap) || 0
+      : 0;
+    const distance = measuredWidth + gap;
+
     const normalizedSpeed = Math.max(speed, 1);
-    setAnimationDuration(Math.max(measuredWidth / normalizedSpeed, 5));
-    setContentWidth(measuredWidth);
+    setAnimationDuration(Math.max(distance / normalizedSpeed, 5));
+    setContentWidth(distance);
   }, [speed]);
 
   React.useEffect(() => {
@@ -82,7 +94,13 @@ export function Marquee({
       onMouseLeave={handleMouseLeave}
     >
       <div
-        className="flex items-center whitespace-nowrap px-10"
+        ref={trackRef}
+        // The gap belongs on the track, not only inside each copy. Quotes
+        // within a copy sat 96px apart while the join between the two copies
+        // was 0px, so once per lap the last quote and the first ran straight
+        // into each other with no space — which is what "the quotes look
+        // squished" was. The more quotes there are, the more often it shows.
+        className="flex items-center gap-24 whitespace-nowrap px-10"
         style={(() => {
           const marqueeStyle: React.CSSProperties & {
             "--marquee-width"?: string;

--- a/tests/unit/client/marquee.test.tsx
+++ b/tests/unit/client/marquee.test.tsx
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest'
+import { render } from '@testing-library/react'
+import { Marquee } from '../../../client/src/components/ui/marquee'
+
+/**
+ * The marquee renders its children twice and scrolls one copy's width, so the
+ * two copies meet once per lap. The spacing at that join comes from the track's
+ * own gap, and it has to match the gap inside each copy — when the track had no
+ * gap at all, every quote sat 96px from its neighbour except the last, which ran
+ * straight into the first with nothing between them.
+ *
+ * jsdom does no layout, so this asserts the structure that produces the spacing
+ * rather than the spacing itself. That is enough to catch the regression: it was
+ * a missing class, not a wrong measurement.
+ */
+describe('Marquee', () => {
+  const renderMarquee = () =>
+    render(
+      <Marquee>
+        <span>first</span>
+        <span>second</span>
+      </Marquee>,
+    )
+
+  /** The `gap-*` utility on an element, whatever size it happens to be. */
+  const gapClass = (element: Element | null | undefined) =>
+    Array.from(element?.classList ?? []).find((name) => name.startsWith('gap-'))
+
+  const trackOf = (container: HTMLElement) =>
+    container.firstElementChild?.firstElementChild ?? null
+
+  it('spaces the join between the copies the same as the items within them', () => {
+    const { container } = renderMarquee()
+    const track = trackOf(container)
+    const copies = Array.from(track?.children ?? [])
+
+    expect(copies).toHaveLength(2)
+    // A track with no gap is the bug; a track whose gap differs from the copies'
+    // is the same bug wearing a different number.
+    expect(gapClass(track)).toBeDefined()
+    for (const copy of copies) {
+      expect(gapClass(copy)).toBe(gapClass(track))
+    }
+  })
+
+  it('renders the children twice and hides the duplicate from assistive tech', () => {
+    const { container } = renderMarquee()
+    const [original, duplicate] = Array.from(trackOf(container)?.children ?? [])
+
+    expect(original.children).toHaveLength(2)
+    expect(duplicate.children).toHaveLength(2)
+    expect(original.getAttribute('aria-hidden')).toBeNull()
+    expect(duplicate.getAttribute('aria-hidden')).toBe('true')
+  })
+
+  it('renders nothing when it has no children', () => {
+    const { container } = render(<Marquee>{null}</Marquee>)
+    expect(container).toBeEmptyDOMElement()
+  })
+})


### PR DESCRIPTION
The quotes banner looked fine with three quotes and "squished" with four.

## What it actually was

The marquee renders its children twice and scrolls one copy's width so the loop is seamless. `gap-24` was on each copy but **not on the track holding them**, so the join between the two copies had no spacing at all.

Measured on the live page, with the four quotes it carries today:

```
gaps between the eight rendered items: 96, 96, 96, 0, 96, 96, 96
                                                   ^ the seam
```

Every quote sits 96px from its neighbour except at the join, where the last quote and the first run together with nothing between them. It is not a width problem and nothing is being compressed — one gap in the cycle is missing. The more quotes there are, the more often that lands in view and the longer the text on either side of it, which is why it started reading as broken at four rather than three.

I should say that my first theory was wrong: I assumed `flex-shrink` was squeezing the items. It is not — `min-width: auto` on flex items already prevents that, and measuring the live page confirmed nothing was overflowing its box. The fix here is the one the measurements actually support.

## The change

- The gap now sits on the track as well, so the seam matches the internal spacing.
- The copy travels its own width **plus** that gap, so the duplicate still lands exactly where the original started. Verified by applying it to the live DOM: all seven gaps become 96px and the travel distance equals the duplicate's offset.
- The gap is read from the computed style rather than hard-coded, so the animation cannot drift from the class if the spacing is ever changed.
- Measures with `getBoundingClientRect().width` instead of `scrollWidth`. `scrollWidth` rounds to an integer and that rounding accumulates into a visible jump each time the loop restarts — unrelated to the reported bug, but the same line and visible once you look for it.

## Test

`tests/unit/client/marquee.test.tsx` asserts the track's gap matches the copies' gap. jsdom does no layout, so it checks the structure that produces the spacing rather than the spacing itself — enough to catch this, which was a missing class rather than a wrong measurement.

Confirmed it fails on the previous markup:

```
× Marquee > spaces the join between the copies the same as the items within them
  → expected undefined to be defined
```

`npm test` (117 passed), `npm run check` and `npm run build` all pass.

## Context

Found while fixing the CMS side of the same report in `pinkytoedev/PISCOC1#33` — deleting a quote there did not remove it from Airtable, which this site reads. The two are independent; this one is display-only and touches no data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)