### PR TITLE
Stop a stray newline in ADMIN_TOKEN from corrupting the refresh request

### DIFF
--- a/.github/workflows/cms-deployed.yml
+++ b/.github/workflows/cms-deployed.yml
@@ -77,11 +77,23 @@ jobs:
         env:
           ADMIN_TOKEN: ${{ secrets.ADMIN_TOKEN }}
         run: |
+          # A GitHub secret keeps whatever whitespace was pasted into it, and
+          # curl passes a newline inside -H straight through to the wire. That
+          # newline ends the header block early, so the header after it — the
+          # Content-Length curl adds for the POST — lands in the request body
+          # instead, and the site rejects it with
+          #   400 {"message":"Unexpected token 'C', \"Content-Le\"... is not valid JSON"}
+          # which names nothing you could act on. Strip it here and say so.
+          token="$(printf '%s' "$ADMIN_TOKEN" | tr -d '\r\n' | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
+          if [ -n "$ADMIN_TOKEN" ] && [ "$token" != "$ADMIN_TOKEN" ]; then
+            echo "::warning::ADMIN_TOKEN has leading/trailing whitespace or a line break; using the trimmed value. Re-save the secret without it — the untrimmed value would corrupt the request, and the Railway variable it is compared against must match the trimmed string."
+          fi
+
           args=(-sS --max-time 60 -o /tmp/refresh.out -w '%{http_code}'
                 -X POST "$SITE/api/cache/refresh"
                 -H 'content-type: application/json' -d '{}')
-          if [ -n "$ADMIN_TOKEN" ]; then
-            args+=(-H "Authorization: Bearer $ADMIN_TOKEN")
+          if [ -n "$token" ]; then
+            args+=(-H "Authorization: Bearer $token")
           else
             echo "::warning::ADMIN_TOKEN is not set as a GitHub secret on this repo; the refresh will be rejected in production."
           fi
@@ -100,6 +112,14 @@ jobs:
               exit 1 ;;
             401)
               echo "::error::401 from /api/cache/refresh: ADMIN_TOKEN is set on the Railway service but does not match the GitHub secret on this repo. They must be the same string."
+              exit 1 ;;
+            400)
+              # The endpoint takes a fixed '{}', so a body the site cannot parse
+              # means the request was corrupted in transit rather than composed
+              # wrongly — a stray character in a header value is how that
+              # happens here.
+              echo "::error::400 from /api/cache/refresh: $body"
+              echo "::error::A JSON parse error here usually means a header value contained a line break and split the request. Check ADMIN_TOKEN for trailing whitespace in the repo's secrets."
               exit 1 ;;
             *)
               echo "::error::Unexpected $code from /api/cache/refresh: $body"


### PR DESCRIPTION
## The failure

```
Error: Unexpected 400 from /api/cache/refresh:
{"message":"Unexpected token 'C', \"Content-Le\"... is not valid JSON"}
```

Nothing is wrong with the site, the endpoint, or the token's value.

## What is actually happening

The step always sends a literal `{}`, so a body the site cannot parse means the request was **corrupted in transit**, not composed wrongly. The `ADMIN_TOKEN` secret ends with a newline, and curl passes a newline inside `-H` through to the wire untouched.

Reproduced against a local express app with `express.json()`:

```
> POST /api/cache/refresh HTTP/1.1
> content-type: application/json
> Authorization: Bearer abc123
>                              <- the newline ends the header block here
> Content-Length: 2            <- so this header becomes the request body
>
< HTTP/1.1 400 Bad Request
```

`Content-Length: 2` is the `"Content-Le"` the JSON parser choked on. The request never reached `requireAdmin` — it died in the body parser.

## The change

The token is trimmed before it goes into the header, with a warning naming what was wrong.

Trimming removes only surrounding whitespace and line breaks, so **a wrong token still fails as a wrong token**. Verified across five cases:

| `ADMIN_TOKEN` | Before | After |
|---|---|---|
| `abc123` | 200 | 200 |
| `abc123\n` — the bug | **400, unexplainable** | warns, 200 |
| `  abc123  ` | 400 | warns, 200 |
| `wrong` | 401 | 401 |
| unset | 401 | 401 |

Also handles `400` explicitly in the status case, so if a header is ever corrupted some other way the run says where to look instead of falling through to "Unexpected".

## What you still need to do

This makes the workflow survive the bad secret; it does not fix the secret. **Re-save `ADMIN_TOKEN` in this repo's secrets without the trailing newline**, and make sure the Railway variable it is compared against holds the same trimmed string — otherwise the trimmed value will start mismatching a Railway value that still has whitespace, and you will get a 401 instead.

## Note on the other copy

`PISCOC1` carries the source-of-truth copy of this workflow at `.github/workflows-for-website-repo/cms-deployed.yml`. That path exists only on its unmerged `fix/health-db-probe` branch, and the installed workflow here is byte-identical to it. If that branch is merged and the template re-copied, this fix would be reverted — the template needs the same change.

YAML parses and `bash -n` passes on the step body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)