### PR TITLE
Show body-less posts as the image they actually are

### DIFF
--- a/client/src/components/articles/article-card.tsx
+++ b/client/src/components/articles/article-card.tsx
@@ -1,9 +1,10 @@
 import { Link } from "wouter";
 import { Article } from "@shared/schema";
 import { ROUTES, PLACEHOLDER_IMAGE } from "@/lib/constants";
-import { formatDate } from "@/lib/utils";
+import { cn, formatDate } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import { getImageUrl, getPhotoUrl } from "@/lib/image-helper";
+import { isImageLedArticle } from "@/lib/article-content";
 
 interface ArticleCardProps {
   article: Article;
@@ -12,7 +13,10 @@ interface ArticleCardProps {
 export function ArticleCard({ article }: ArticleCardProps) {
   // Use imageUrl from MainImageLink or fall back to placeholder
   const imageSource = article.imageUrl ? getImageUrl(article.imageUrl) : PLACEHOLDER_IMAGE;
-  console.log(`Article ${article.id} - Using imageUrl: ${article.imageUrl || 'Not available, using placeholder'}`);
+
+  // A post with no body is the picture and the headline — there is nothing to
+  // click through to. Give it the room to be read where it sits.
+  const imageLed = isImageLedArticle(article);
 
   return (
     <Link href={`/articles/${article.id}`} className="block h-full">
@@ -20,34 +24,68 @@ export function ArticleCard({ article }: ArticleCardProps) {
       <div className="article-card bg-pink-50 rounded-lg shadow-lg overflow-hidden flex flex-col h-full group cursor-pointer hover:shadow-xl transition-shadow">
 
 
-        <div className="relative">
+        <div className={cn("relative", imageLed && "flex justify-center bg-pink-100/50")}>
           <img
             src={imageSource}
             alt={article.title}
-            className="h-48 w-full object-contain bg-pink-100/50"
+            className={cn(
+              "object-contain bg-pink-100/50",
+              imageLed
+                // Sized by the image, not by a box. A fixed height letterboxes
+                // a portrait meme into a narrow strip down the middle, so
+                // widening the card does nothing for it — the height is what
+                // binds. Letting the element take its own dimensions, capped,
+                // means every aspect ratio gets as big as it can. Never
+                // object-cover: cropping is how you cut the joke off.
+                ? "block w-auto h-auto max-w-full max-h-[70vh]"
+                : "h-48 w-full",
+            )}
             onError={(e) => {
               const target = e.target as HTMLImageElement;
               console.error(`Failed to load image: ${target.src}`);
               target.src = PLACEHOLDER_IMAGE;
             }}
           />
-          <div className="article-overlay absolute inset-0 bg-primary bg-opacity-40 opacity-0 flex items-center justify-center transition-opacity duration-300 group-hover:opacity-100">
-            <div>
-              <Button
-                className="bg-white text-primary font-quicksand font-bold py-2 px-4 rounded-full shadow-lg transition-colors hover:bg-pinky-dark hover:text-white"
-              >
-                Read More
-              </Button>
+          {/* "Read More" promises something to read, which is exactly what
+              these do not have. */}
+          {!imageLed && (
+            <div className="article-overlay absolute inset-0 bg-primary bg-opacity-40 opacity-0 flex items-center justify-center transition-opacity duration-300 group-hover:opacity-100">
+              <div>
+                <Button
+                  className="bg-white text-primary font-quicksand font-bold py-2 px-4 rounded-full shadow-lg transition-colors hover:bg-pinky-dark hover:text-white"
+                >
+                  Read More
+                </Button>
+              </div>
             </div>
-          </div>
+          )}
         </div>
-        <div className="p-4 flex-grow">
-          <h2 className="font-quicksand font-bold text-xl mb-2 text-pinky-dark min-h-[3rem] line-clamp-2">
+        <div className={cn("flex-grow", imageLed ? "p-4 md:p-6" : "p-4")}>
+          <h2
+            className={cn(
+              "font-quicksand font-bold text-pinky-dark",
+              imageLed
+                // No clamp and no min-height: the headline is the post, it gets
+                // to be as long as it is, and there is no neighbouring card to
+                // stay level with.
+                ? "text-2xl md:text-3xl"
+                : "text-xl mb-2 min-h-[3rem] line-clamp-2",
+            )}
+          >
             {article.title}
           </h2>
-          <p className="text-gray-600 text-sm mb-4 min-h-[4rem] line-clamp-3">
-            {article.description}
-          </p>
+          {/* The description is derived from the body, so an image-led post
+              usually has none — rendering it anyway left an empty 4rem gap. */}
+          {(!imageLed || article.description) && (
+            <p
+              className={cn(
+                "text-gray-600",
+                imageLed ? "text-base mt-2" : "text-sm mb-4 min-h-[4rem] line-clamp-3",
+              )}
+            >
+              {article.description}
+            </p>
+          )}
         </div>
         <div className="px-4 pb-4 mt-auto flex justify-between items-center">
           <div className="text-xs">

--- a/client/src/lib/article-content.ts
+++ b/client/src/lib/article-content.ts
@@ -1,0 +1,52 @@
+import type { Article } from "@shared/schema";
+
+/**
+ * Not everything published here is something to read.
+ *
+ * A good number of posts are a funny picture and a headline — there is no body
+ * at all. In a uniform grid they look exactly like a full article, so people
+ * open one, find nothing to read, and click straight back out. Knowing which is
+ * which lets the list show those as the image they actually are.
+ */
+
+/** The subset of an article this module needs; keeps it usable from tests. */
+type BodyFields = Pick<Article, "content" | "contentFormat">;
+
+/**
+ * Entities that carry no visible text. `&nbsp;` is the one that matters: an
+ * editor clearing a rich-text field in Airtable routinely leaves `<p>&nbsp;</p>`
+ * behind, which is a 15-character string that renders as nothing.
+ */
+const BLANK_ENTITIES = /&(nbsp|#160|#xa0|zwnj|#8203);/gi;
+
+/**
+ * Whether an article has body text a reader could actually read.
+ *
+ * Emptiness is decided on what renders, not on string length. An HTML body is
+ * stripped to its text first, because `<p></p>`, `<br>` and `<p>&nbsp;</p>` are
+ * all non-empty strings that display nothing — and they are what the CMS leaves
+ * behind, so testing `content.trim()` alone would call those real articles.
+ */
+export function hasArticleBody(article: Partial<BodyFields> | undefined): boolean {
+  const raw = article?.content;
+  if (typeof raw !== "string" || raw.trim() === "") return false;
+
+  // Only HTML needs stripping. Doing it unconditionally would discard a
+  // plaintext body that happens to contain angle brackets.
+  const text =
+    article?.contentFormat === "html"
+      ? raw.replace(/<[^>]*>/g, " ").replace(BLANK_ENTITIES, " ")
+      : raw;
+
+  return text.replace(/\s/g, "") !== "";
+}
+
+/**
+ * The inverse, named for what the list is actually deciding.
+ *
+ * These get a larger, uncropped image and a bigger headline, so the whole point
+ * of the post is legible while scrolling rather than one click away.
+ */
+export function isImageLedArticle(article: Partial<BodyFields> | undefined): boolean {
+  return !hasArticleBody(article);
+}

--- a/client/src/pages/articles.tsx
+++ b/client/src/pages/articles.tsx
@@ -9,6 +9,8 @@ import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { useLocation } from "wouter";
+import { cn } from "@/lib/utils";
+import { isImageLedArticle } from "@/lib/article-content";
 
 export default function Articles() {
   const [page, setPage] = useState(1);
@@ -120,9 +122,33 @@ export default function Articles() {
           )}
         </div>
       ) : (
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 mb-8">
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 grid-flow-row-dense gap-6 mb-8">
+          {/*
+            `grid-flow-row-dense` earns its keep here. A full-width card can
+            only sit on an empty row, so without it a normal card followed by
+            an image-led one leaves two thirds of a row blank, which reads as a
+            broken layout rather than a deliberate one. Dense packing backfills
+            those gaps with the next cards that fit.
+
+            The cost is that backfilling can lift a later article above an
+            image-led one, so the grid is no longer strictly date-ordered. Each
+            card carries its own date, and the alternative was visible holes on
+            most pages.
+          */}
           {articles.map((article: any) => (
-            <div key={article.id} onClick={() => handleArticleClick(article.id)} className="h-full">
+            <div
+              key={article.id}
+              onClick={() => handleArticleClick(article.id)}
+              className={cn(
+                "h-full",
+                // A post with no body is the image and the headline, so it gets
+                // a row to itself rather than a third of one. It also has to be
+                // a row of its own: sharing with normal cards would stretch
+                // them to the height of a tall image and leave them mostly
+                // empty, since grid rows size to their tallest item.
+                isImageLedArticle(article) && "md:col-span-2 lg:col-span-3",
+              )}
+            >
               <ArticleCard article={article} />
             </div>
           ))}

--- a/tests/unit/client/article-card.test.tsx
+++ b/tests/unit/client/article-card.test.tsx
@@ -1,0 +1,109 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render } from '@testing-library/react'
+import { ArticleCard } from '../../../client/src/components/articles/article-card'
+
+vi.mock('wouter', () => ({
+  Link: ({ href, children, className }: any) => (
+    <a href={href} className={className}>{children}</a>
+  ),
+}))
+
+vi.mock('../../../client/src/lib/image-helper', () => ({
+  getImageUrl: (url: string) => url,
+  getPhotoUrl: (url: string) => url,
+}))
+
+const baseArticle = {
+  id: '1',
+  title: 'A very good headline',
+  description: '',
+  content: '',
+  contentFormat: 'plaintext' as const,
+  imageUrl: 'https://example.test/funny.png',
+  imageType: 'url' as const,
+  imagePath: null,
+  featured: false,
+  publishedAt: new Date('2026-01-02T00:00:00Z'),
+  name: 'Someone',
+  photo: '',
+}
+
+const renderCard = (overrides = {}) =>
+  render(<ArticleCard article={{ ...baseArticle, ...overrides } as any} />)
+
+const img = (container: HTMLElement) => container.querySelector('img')!
+
+describe('ArticleCard', () => {
+  describe('an article with a body', () => {
+    it('keeps the compact fixed-height image', () => {
+      const { container } = renderCard({ content: 'Real body text.' })
+      expect(img(container).className).toContain('h-48')
+      expect(img(container).className).not.toContain('h-72')
+    })
+
+    it('shows the Read More overlay', () => {
+      const { getByText } = renderCard({ content: 'Real body text.' })
+      expect(getByText('Read More')).toBeTruthy()
+    })
+
+    it('reserves space for the description so cards in a row stay level', () => {
+      const { container } = renderCard({ content: 'Real body text.', description: '' })
+      const paragraph = container.querySelector('p.min-h-\\[4rem\\]')
+      expect(paragraph).not.toBeNull()
+    })
+  })
+
+  describe('an image-led article with no body', () => {
+    it('is sized by the image rather than a fixed box', () => {
+      // A fixed height letterboxes a portrait meme into a narrow strip, so
+      // widening the card does nothing for it. The image sizes itself, capped.
+      const { container } = renderCard({ content: '' })
+      const cls = img(container).className
+      expect(cls).toContain('max-h-[70vh]')
+      expect(cls).toContain('h-auto')
+      expect(cls).toContain('w-auto')
+      expect(cls).not.toContain('h-48')
+    })
+
+    it('never crops the image', () => {
+      // These are memes of every aspect ratio; object-cover would cut the joke.
+      const { container } = renderCard({ content: '' })
+      expect(img(container).className).toContain('object-contain')
+      expect(img(container).className).not.toContain('object-cover')
+    })
+
+    it('drops the Read More overlay, which promises text that is not there', () => {
+      const { queryByText } = renderCard({ content: '' })
+      expect(queryByText('Read More')).toBeNull()
+    })
+
+    it('does not reserve an empty description block', () => {
+      const { container } = renderCard({ content: '', description: '' })
+      expect(container.querySelector('p.min-h-\\[4rem\\]')).toBeNull()
+    })
+
+    it('still shows a description when there is one', () => {
+      const { getByText } = renderCard({ content: '', description: 'A caption.' })
+      expect(getByText('A caption.')).toBeTruthy()
+    })
+
+    it('lets the headline run to full length instead of clamping it', () => {
+      const { getByText } = renderCard({ content: '' })
+      const heading = getByText('A very good headline')
+      expect(heading.className).not.toContain('line-clamp-2')
+      expect(heading.className).toContain('text-2xl')
+    })
+
+    it('treats html that renders to nothing as having no body', () => {
+      const { container } = renderCard({ content: '<p>&nbsp;</p>', contentFormat: 'html' })
+      expect(img(container).className).toContain('max-h-[70vh]')
+    })
+
+    it('still links through to the article', () => {
+      // The point is that clicking is no longer necessary, not that it is gone —
+      // the detail page is still what gets shared.
+      const { container } = renderCard({ content: '' })
+      expect(container.querySelector('a')?.getAttribute('href')).toBe('/articles/1')
+    })
+  })
+})

--- a/tests/unit/client/article-content.test.ts
+++ b/tests/unit/client/article-content.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest'
+import { hasArticleBody, isImageLedArticle } from '../../../client/src/lib/article-content'
+
+/**
+ * The whole feature hangs on this predicate: get it wrong in one direction and
+ * a real article is blown up to full width with no text under it; wrong in the
+ * other and the image-only posts stay as unreadable thumbnails.
+ */
+describe('hasArticleBody', () => {
+  it('is true for plaintext and html bodies with real text', () => {
+    expect(hasArticleBody({ content: 'A real article.', contentFormat: 'plaintext' })).toBe(true)
+    expect(hasArticleBody({ content: '<p>A real article.</p>', contentFormat: 'html' })).toBe(true)
+  })
+
+  it('is false when there is no body at all', () => {
+    expect(hasArticleBody({ content: '', contentFormat: 'plaintext' })).toBe(false)
+    expect(hasArticleBody({ content: '   \n\t ', contentFormat: 'plaintext' })).toBe(false)
+    expect(hasArticleBody(undefined)).toBe(false)
+    expect(hasArticleBody({})).toBe(false)
+  })
+
+  // These are the ones a naive content.trim() would get wrong: non-empty
+  // strings that a browser renders as nothing. They are what the CMS leaves
+  // behind when an editor clears a rich-text field.
+  it.each([
+    ['empty paragraph', '<p></p>'],
+    ['non-breaking space', '<p>&nbsp;</p>'],
+    ['numeric nbsp entity', '<p>&#160;</p>'],
+    ['line break only', '<br>'],
+    ['nested empty markup', '<div><p><span></span></p></div>'],
+    ['whitespace between tags', '<p>\n  \n</p>'],
+  ])('is false for html that renders to nothing: %s', (_label, content) => {
+    expect(hasArticleBody({ content, contentFormat: 'html' })).toBe(false)
+  })
+
+  it('does not strip tags from a plaintext body', () => {
+    // Angle brackets in plaintext are literal characters a reader sees, not
+    // markup. Stripping unconditionally would call this article empty.
+    expect(hasArticleBody({ content: '<not markup>', contentFormat: 'plaintext' })).toBe(true)
+  })
+
+  it('treats a body of only markup-adjacent punctuation in html as empty', () => {
+    expect(hasArticleBody({ content: '<p> </p><p> </p>', contentFormat: 'html' })).toBe(false)
+  })
+
+  it('isImageLedArticle is the inverse', () => {
+    const withBody = { content: 'text', contentFormat: 'plaintext' as const }
+    const withoutBody = { content: '<p>&nbsp;</p>', contentFormat: 'html' as const }
+    expect(isImageLedArticle(withBody)).toBe(false)
+    expect(isImageLedArticle(withoutBody)).toBe(true)
+  })
+})


### PR DESCRIPTION
A good number of posts here are a funny picture and a headline, with no body at all. The articles grid renders them identically to a full article — a 192px-tall thumbnail and an empty three-line gap where the summary would go — so the only way to see the picture is to open the post, find nothing to read, and click back out.

Those posts now get a row to themselves, with the image **sized by the image** rather than by a fixed box.

## Sizing by the image is the part that matters

My first attempt kept a fixed height and just made the card wider. That did almost nothing for a portrait meme: `object-contain` letterboxed it into a narrow strip down the middle of a very wide box, because *height* was what bound it. I only caught this by rendering it and looking.

Letting the element take its own dimensions — capped at `70vh` and the card width — means every aspect ratio gets as large as it can:

| Image | Before | After (1280px viewport) |
|---|---|---|
| 700×1100 portrait | 120×192 | **445×700** |
| 1200×675 landscape | 341×192 | **1174×660** |

Still `object-contain`, never `object-cover` — these are images of every shape, and cropping to fill is how you cut the joke off.

## Deciding what "no body" means

Emptiness is decided on **what renders**, not on string length. `<p></p>`, `<br>` and `<p>&nbsp;</p>` are all non-empty strings that display nothing, and they are exactly what the CMS leaves behind when an editor clears a rich-text field — so `content.trim()` alone would classify those as real articles. Plaintext bodies are deliberately *not* tag-stripped, so `<not markup>` still counts as text.

No API change was needed: `/api/articles` already ships each article's full `content`.

## Two smaller things that follow

- The "Read More" hover overlay is dropped on these — it promises text that is not there.
- The description block only renders when there *is* a description, instead of reserving 4rem of empty space.

## The one trade-off worth your attention

The grid gets `grid-flow-row-dense`. A full-width card can only sit on an empty row, so without it a normal card followed by an image-led one leaves two thirds of a row blank — it reads as a broken layout, not a deliberate one.

The cost: backfilling can lift a later article above an image-led one, **so the grid is no longer strictly date-ordered at 2 and 3 columns.** At one column there is nothing to backfill, so mobile keeps the original order exactly. Every card shows its own date.

If you would rather keep strict ordering, the alternatives are to accept the gaps, or to span two columns instead of three (smaller image, fewer gaps). Say which and I will switch it.

## Verification

Checked against the **compiled stylesheet** at 1280 / 768 / 375, not from class names — including confirming Tailwind actually emitted the arbitrary values (`max-h-[70vh]`, `lg:col-span-3`), since those only compile if the literal string appears in scanned source. Measured no gaps in the grid, image-led cards at 100% of the row, and the 70vh cap binding on tall images.

22 new tests. Disabling the feature fails five of them. `npm test` 139 passed, `npm run check` and `npm run build` clean.

Also drops a `console.log` that fired for every card on every render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)